### PR TITLE
Add --globoff option to curl

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -24,4 +24,4 @@ function export_env_vars() {
 
 export_env_vars
 echo "-----> Running curl $BUILDPACK_WEBHOOK_URL"
-curl "$BUILDPACK_WEBHOOK_URL"
+curl --globoff "$BUILDPACK_WEBHOOK_URL"


### PR DESCRIPTION
We don't want it to interpret the `[]` in the URL